### PR TITLE
Update openai_api.py

### DIFF
--- a/src/openai_api.py
+++ b/src/openai_api.py
@@ -178,7 +178,7 @@ class OpenAI(AIEngine):  # pylint: disable=too-many-instance-attributes
                     leftovers = b''
 
             elif t == "conversation.item.created":
-                if msg["item"]["status"] == "completed":
+                if msg["item"].get('status') == "completed":
                     self.drain_queue()
             elif t == "conversation.item.input_audio_transcription.completed":
                 logging.info("Speaker: %s", msg["transcript"].rstrip())


### PR DESCRIPTION
if you use function_call_output then the message does not contain the "status" field, which is why an error occurs

```
            elif t == "response.function_call_arguments.done":
                if msg["name"] == "terminate_call":
                    logging.info(t)
                    self.terminate_call()
                elif msg["name"] == "random_color":
                    color = self.random_color()
                    payload = {
                        "type": "conversation.item.create",
                        "item": {
                            "type": "function_call_output",
                            "call_id": msg['call_id'],
                            "output": color
                        }
                    }
                    await self.ws.send(json.dumps(payload))
                    await self.ws.send(json.dumps({"type": "response.create"}))
```